### PR TITLE
Add transport options documentation for GitHub Project Manager

### DIFF
--- a/.changeset/afraid-ghosts-live.md
+++ b/.changeset/afraid-ghosts-live.md
@@ -1,5 +1,0 @@
----
-'@monsoft/mcp-github-project-manager': minor
----
-
-feat: Implement SSE transport for GitHub Project Manager

--- a/.changeset/afraid-ghosts-live.md
+++ b/.changeset/afraid-ghosts-live.md
@@ -1,0 +1,5 @@
+---
+'@monsoft/mcp-github-project-manager': minor
+---
+
+feat: Implement SSE transport for GitHub Project Manager

--- a/changes/2025-03-18.md
+++ b/changes/2025-03-18.md
@@ -6,3 +6,10 @@
 - Added support for running the GitHub MCP using npx
 - Implemented parameter passing for environment configuration
 - Updated documentation with new usage instructions
+
+## Added transport options documentation to README - 03:45 pm
+
+- Updated README to include details about available transport options (Stdio and SSE)
+- Added documentation for command line parameters to specify transport type and port
+- Included examples of using both transport methods with various configurations
+- Added programmatic usage examples for both transport types

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,12 @@
                 "apps/*",
                 "packages/*"
             ],
+            "dependencies": {
+                "express": "^5.0.1"
+            },
             "devDependencies": {
                 "@changesets/cli": "^2.28.1",
+                "@types/express": "^5.0.0",
                 "husky": "^9.0.11",
                 "lint-staged": "^15.2.2",
                 "prettier": "^3.5.3",
@@ -2323,12 +2327,59 @@
                 "@babel/types": "^7.20.7"
             }
         },
+        "node_modules/@types/body-parser": {
+            "version": "1.19.5",
+            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+            "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/connect": "*",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/connect": {
+            "version": "3.4.38",
+            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+            "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/estree": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
             "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/express": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.0.tgz",
+            "integrity": "sha512-DvZriSMehGHL1ZNLzi6MidnsDhUZM/x2pRdDIKdwbUNqqwHxMlRdkxtn6/EPKyqKpHqTl/4nRZsRNLpZxZRpPQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/body-parser": "*",
+                "@types/express-serve-static-core": "^5.0.0",
+                "@types/qs": "*",
+                "@types/serve-static": "*"
+            }
+        },
+        "node_modules/@types/express-serve-static-core": {
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
+            "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/qs": "*",
+                "@types/range-parser": "*",
+                "@types/send": "*"
+            }
         },
         "node_modules/@types/graceful-fs": {
             "version": "4.1.9",
@@ -2339,6 +2390,13 @@
             "dependencies": {
                 "@types/node": "*"
             }
+        },
+        "node_modules/@types/http-errors": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+            "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/istanbul-lib-coverage": {
             "version": "2.0.6",
@@ -2385,6 +2443,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/mime": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+            "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/node": {
             "version": "22.13.9",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
@@ -2404,12 +2469,49 @@
                 "form-data": "^4.0.0"
             }
         },
+        "node_modules/@types/qs": {
+            "version": "6.9.18",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+            "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/range-parser": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/semver": {
             "version": "7.5.8",
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
             "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/send": {
+            "version": "0.17.4",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+            "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mime": "^1",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/serve-static": {
+            "version": "1.15.7",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
+            "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/http-errors": "*",
+                "@types/node": "*",
+                "@types/send": "*"
+            }
         },
         "node_modules/@types/stack-utils": {
             "version": "2.0.3",
@@ -11967,7 +12069,7 @@
         },
         "packages/mcp-github-project-manager": {
             "name": "@monsoft/mcp-github-project-manager",
-            "version": "1.1.0",
+            "version": "1.4.0",
             "license": "MIT",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.6.1",
@@ -11977,7 +12079,7 @@
                 "zod": "^3.22.4"
             },
             "bin": {
-                "github-project-manager": "dist/src/server/index.js"
+                "github-project-manager": "dist/src/index.js"
             },
             "devDependencies": {
                 "@jest/globals": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     },
     "devDependencies": {
         "@changesets/cli": "^2.28.1",
+        "@types/express": "^5.0.0",
         "husky": "^9.0.11",
         "lint-staged": "^15.2.2",
         "prettier": "^3.5.3",
@@ -32,5 +33,8 @@
     ],
     "lint-staged": {
         "*.{ts,tsx,js,jsx,md}": "prettier --write"
+    },
+    "dependencies": {
+        "express": "^5.0.1"
     }
 }

--- a/packages/mcp-github-project-manager/CHANGELOG.md
+++ b/packages/mcp-github-project-manager/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @monsoft/mcp-github-project-manager
 
+## 1.5.0
+
+### Minor Changes
+
+- e6179ae: feat: Implement SSE transport for GitHub Project Manager
+
 ## 1.4.0
 
 ### Minor Changes

--- a/packages/mcp-github-project-manager/README.md
+++ b/packages/mcp-github-project-manager/README.md
@@ -51,6 +51,36 @@ npx -y @monsoft/mcp-github-project-manager --GITHUB_PERSONAL_TOKEN=your_github_t
 
 This starts the MCP server which can then be connected to by MCP clients.
 
+### Transport Options
+
+The GitHub Project Manager supports two transport methods:
+
+#### Stdio Transport (Default)
+
+This is the default transport, ideal for direct CLI integrations and local usage:
+
+```bash
+# Start with default Stdio transport
+npx -y @monsoft/mcp-github-project-manager --GITHUB_PERSONAL_TOKEN=your_github_token_here
+```
+
+#### Server-Sent Events (SSE) Transport
+
+For remote setups and web integrations, you can use the SSE transport which starts an HTTP server:
+
+```bash
+# Start with SSE transport on default port (3010)
+npx -y @monsoft/mcp-github-project-manager --GITHUB_PERSONAL_TOKEN=your_github_token_here --RUN_SSE=1
+
+# Start with SSE transport on a custom port
+npx -y @monsoft/mcp-github-project-manager --GITHUB_PERSONAL_TOKEN=your_github_token_here --RUN_SSE=1 --PORT=8080
+```
+
+When using SSE transport, the server will be accessible at:
+
+- SSE endpoint: `http://localhost:<PORT>/sse`
+- Messages endpoint: `http://localhost:<PORT>/messages`
+
 ### Setting Up with MCP Clients
 
 To use this with AI assistants like Claude in Anthropic or Cursor:
@@ -79,6 +109,31 @@ When running your application, provide the GitHub token as a command-line argume
 
 ```bash
 node your-app.js --GITHUB_PERSONAL_TOKEN=your_github_token_here
+```
+
+You can also specify the transport type and other options:
+
+```bash
+# Use SSE transport
+node your-app.js --GITHUB_PERSONAL_TOKEN=your_github_token_here --RUN_SSE=1 --PORT=3010
+
+# Use default Stdio transport
+node your-app.js --GITHUB_PERSONAL_TOKEN=your_github_token_here
+```
+
+If you need to programmatically start the server with specific transport options:
+
+```typescript
+import {
+    startGitHubProjectManagerServer,
+    startGitHubProjectManagerServerSSE,
+} from '@monsoft/mcp-github-project-manager';
+
+// Start with Stdio transport
+await startGitHubProjectManagerServer('your_github_token_here');
+
+// Or start with SSE transport
+await startGitHubProjectManagerServerSSE('your_github_token_here', 3010);
 ```
 
 ## API Reference

--- a/packages/mcp-github-project-manager/package.json
+++ b/packages/mcp-github-project-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monsoft/mcp-github-project-manager",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A Model Context Protocol GitHub Project Manager implementation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-github-project-manager/src/config/env.ts
+++ b/packages/mcp-github-project-manager/src/config/env.ts
@@ -9,11 +9,14 @@ import { MissingGitHubTokenError } from '../errors/index.js';
  */
 export type EnvConfig = {
     GITHUB_PERSONAL_TOKEN: string;
-    [key: string]: string;
+    PORT: number;
+    RUN_SSE: number;
 };
 
 const envConfigSchema = z.object({
     GITHUB_PERSONAL_TOKEN: z.string().describe('GitHub personal access token'),
+    PORT: z.number().describe('Port to run the server on').optional().default(3010),
+    RUN_SSE: z.number().describe('Run the server in SSE mode').optional().default(0),
 });
 
 /**
@@ -29,9 +32,16 @@ const envConfigSchema = z.object({
 function parseArgs() {
     const args = yargs(hideBin(process.argv)).parse();
 
+    console.log(args);
+
     const envConfig = envConfigSchema.safeParse(args);
 
-    return envConfig.success ? envConfig.data : undefined;
+    if (!envConfig.success) {
+        console.error(envConfig.error);
+        return undefined;
+    }
+
+    return envConfig.data;
 }
 
 /**

--- a/packages/mcp-github-project-manager/src/index.ts
+++ b/packages/mcp-github-project-manager/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { startGitHubProjectManagerServer } from './server/github-project-manager.js';
+import { startGitHubProjectManagerServerSSE } from './server/github-project-manager-sse.js';
 import { loadEnv } from './config/env.js';
 
 /**
@@ -14,8 +15,13 @@ async function main() {
     // Load environment variables from file
     const env = loadEnv();
     const token = env.GITHUB_PERSONAL_TOKEN;
-
-    await startGitHubProjectManagerServer(token);
+    const runSSE = env.RUN_SSE;
+    const port = env.PORT;
+    if (runSSE) {
+        await startGitHubProjectManagerServerSSE(token, port);
+    } else {
+        await startGitHubProjectManagerServer(token);
+    }
     // The server will keep running until terminated
 }
 

--- a/packages/mcp-github-project-manager/src/server/github-project-manager-sse.ts
+++ b/packages/mcp-github-project-manager/src/server/github-project-manager-sse.ts
@@ -1,0 +1,1016 @@
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import { z } from 'zod';
+import { GitHubIssueService, GitHubProjectService, GitHubPullRequestService } from '../services/index.js';
+import { AuthenticationError, ResourceNotFoundError, ValidationError } from '../errors/index.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import express from 'express';
+
+// Environment variable for GitHub token
+
+/**
+ * Initialize and start the MCP GitHub Project Manager server
+ */
+export async function startGitHubProjectManagerServerSSE(token: string, port: number) {
+    // Use provided token or environment variable
+    const githubToken = token;
+
+    // Validate GitHub token
+    if (!githubToken) {
+        console.error('GITHUB_TOKEN environment variable is required');
+        process.exit(1);
+    }
+
+    // Create services
+    const issueService = new GitHubIssueService(githubToken);
+    const projectService = new GitHubProjectService(githubToken);
+    const pullRequestService = new GitHubPullRequestService(githubToken);
+
+    // Create a new MCP server
+    const server = new McpServer({
+        name: 'MCP GitHub Project Manager',
+        version: '1.0.0',
+    });
+
+    const app = express();
+
+    // Register GitHub Issue Management tools
+    registerIssueTools(server, issueService);
+
+    // Register GitHub Project Management tools
+    registerProjectTools(server, projectService);
+
+    // Register GitHub Pull Request Management tools
+    registerPullRequestTools(server, pullRequestService);
+
+    let transport: SSEServerTransport | null = null;
+
+    app.get('/sse', (_req: express.Request, res: express.Response) => {
+        transport = new SSEServerTransport('/messages', res);
+        server.connect(transport);
+    });
+
+    app.post('/messages', (req: express.Request, res: express.Response) => {
+        if (transport) {
+            transport.handlePostMessage(req, res);
+        }
+    });
+
+    app.listen(port, () => {
+        console.log(`MCP GitHub Project Manager server started on port ${port}`);
+    });
+
+    // Keep the server running
+    return server;
+}
+
+/**
+ * Register GitHub Issue Management tools
+ */
+function registerIssueTools(server: McpServer, issueService: GitHubIssueService) {
+    // Create Issue Tool
+    server.tool(
+        'create_issue',
+        'Create a new issue in a GitHub repository',
+        {
+            owner: z.string().describe('Repository owner (username or organization)'),
+            repo: z.string().describe('Repository name'),
+            title: z.string().describe('Issue title'),
+            body: z.string().optional().describe('Issue body/description'),
+            labels: z.array(z.string()).optional().describe('Labels to add to this issue'),
+            assignees: z.array(z.string()).optional().describe('GitHub usernames to assign to this issue'),
+            milestone: z.number().optional().describe('Milestone number to associate with this issue'),
+        },
+        async (args, _extra) => {
+            try {
+                const issue = await issueService.createIssue(args);
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({
+                                success: true,
+                                issue: {
+                                    number: issue.number,
+                                    title: issue.title,
+                                    html_url: issue.html_url,
+                                    state: issue.state,
+                                    created_at: issue.created_at,
+                                },
+                            }),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return handleToolError(error);
+            }
+        },
+    );
+
+    // Update Issue Tool
+    server.tool(
+        'update_issue',
+        'Update an existing issue in a GitHub repository',
+        {
+            owner: z.string().describe('Repository owner (username or organization)'),
+            repo: z.string().describe('Repository name'),
+            issue_number: z.number().describe('Issue number'),
+            title: z.string().optional().describe('New issue title'),
+            body: z.string().optional().describe('New issue body'),
+            state: z.enum(['open', 'closed']).optional().describe('New issue state'),
+            labels: z.array(z.string()).optional().describe('Labels to set'),
+            assignees: z.array(z.string()).optional().describe('GitHub usernames to assign'),
+            milestone: z.number().nullable().optional().describe('Milestone to set'),
+        },
+        async (args, _extra) => {
+            try {
+                const issue = await issueService.updateIssue(args);
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({
+                                success: true,
+                                issue: {
+                                    number: issue.number,
+                                    title: issue.title,
+                                    html_url: issue.html_url,
+                                    state: issue.state,
+                                    updated_at: issue.updated_at,
+                                },
+                            }),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return handleToolError(error);
+            }
+        },
+    );
+
+    // List Issues Tool
+    server.tool(
+        'list_issues',
+        'List issues in a GitHub repository with filtering options',
+        {
+            owner: z.string().describe('Repository owner (username or organization)'),
+            repo: z.string().describe('Repository name'),
+            state: z.enum(['open', 'closed', 'all']).optional().describe('Issue state'),
+            sort: z.enum(['created', 'updated', 'comments']).optional().describe('Sort field'),
+            direction: z.enum(['asc', 'desc']).optional().describe('Sort direction'),
+            since: z.string().optional().describe('Filter by updated date (ISO 8601 format)'),
+            per_page: z.number().optional().describe('Results per page'),
+            page: z.number().optional().describe('Page number'),
+            labels: z.array(z.string()).optional().describe('Filter by labels'),
+            assignee: z.string().optional().describe('Filter by assignee'),
+            creator: z.string().optional().describe('Filter by creator'),
+            mentioned: z.string().optional().describe('Filter by mentioned user'),
+            milestone: z.string().optional().describe('Filter by milestone number or title'),
+        },
+        async (args, _extra) => {
+            try {
+                const issues = await issueService.listIssues(args);
+
+                // Format the response to include only necessary information
+                const formattedIssues = issues.map((issue: any) => ({
+                    number: issue.number,
+                    title: issue.title,
+                    state: issue.state,
+                    html_url: issue.html_url,
+                    created_at: issue.created_at,
+                    updated_at: issue.updated_at,
+                    labels: issue.labels.map((label: any) => ({
+                        name: label.name,
+                        color: label.color,
+                    })),
+                    assignees: issue.assignees.map((assignee: any) => assignee.login),
+                }));
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({
+                                success: true,
+                                count: formattedIssues.length,
+                                issues: formattedIssues,
+                            }),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return handleToolError(error);
+            }
+        },
+    );
+
+    // Get Issue Tool
+    server.tool(
+        'get_issue',
+        'Get details of a specific issue in a GitHub repository.',
+        {
+            owner: z.string().describe('Repository owner (username or organization)'),
+            repo: z.string().describe('Repository name'),
+            issue_number: z.number().describe('Issue number'),
+        },
+        async (args, _extra) => {
+            try {
+                const issue = await issueService.getIssue(args);
+
+                // Format the response
+                const formattedIssue = {
+                    number: issue.number,
+                    title: issue.title,
+                    body: issue.body,
+                    state: issue.state,
+                    html_url: issue.html_url,
+                    created_at: issue.created_at,
+                    updated_at: issue.updated_at,
+                    closed_at: issue.closed_at,
+                    labels: issue.labels.map((label: any) => ({
+                        name: label.name,
+                        color: label.color,
+                    })),
+                    assignees: issue.assignees?.map((assignee: any) => assignee.login) || [],
+                    milestone: issue.milestone
+                        ? {
+                              number: issue.milestone.number,
+                              title: issue.milestone.title,
+                          }
+                        : null,
+                    comments: issue.comments,
+                };
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({
+                                success: true,
+                                issue: formattedIssue,
+                            }),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return handleToolError(error);
+            }
+        },
+    );
+
+    // Add Issue Comment Tool
+    server.tool(
+        'add_issue_comment',
+        'Add a comment to an existing issue',
+        {
+            owner: z.string().describe('Repository owner (username or organization)'),
+            repo: z.string().describe('Repository name'),
+            issue_number: z.number().describe('Issue number'),
+            body: z.string().describe('Comment text'),
+        },
+        async (args, _extra) => {
+            try {
+                const comment = await issueService.addIssueComment(args);
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({
+                                success: true,
+                                comment: {
+                                    id: comment.id,
+                                    body: comment.body,
+                                    html_url: comment.html_url,
+                                    created_at: comment.created_at,
+                                },
+                            }),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return handleToolError(error);
+            }
+        },
+    );
+}
+
+/**
+ * Register GitHub Project Management tools
+ */
+function registerProjectTools(server: McpServer, projectService: GitHubProjectService) {
+    // Create Project Tool
+    server.tool(
+        'create_project',
+        'Create a new GitHub project board',
+        {
+            owner: z.string().describe('Organization name or username'),
+            name: z.string().describe('Project name'),
+            body: z.string().optional().describe('Project description'),
+        },
+        async (args, _extra) => {
+            try {
+                const project = await projectService.createProject(args);
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({
+                                success: true,
+                                project: {
+                                    id: project.id,
+                                    name: project.name,
+                                    html_url: project.html_url,
+                                    created_at: project.created_at,
+                                },
+                            }),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return handleToolError(error);
+            }
+        },
+    );
+
+    // Add Project Item Tool
+    server.tool(
+        'add_project_item',
+        'Add an issue or pull request to a GitHub project',
+        {
+            project_id: z.number().describe('Project ID'),
+            content_id: z.number().describe('Issue or PR ID'),
+            content_type: z.enum(['Issue', 'PullRequest']).describe('Type of content to add'),
+        },
+        async (args, _extra) => {
+            try {
+                const card = await projectService.addProjectItem(args);
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({
+                                success: true,
+                                card: {
+                                    id: card.id,
+                                    url: card.url,
+                                    created_at: card.created_at,
+                                },
+                            }),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return handleToolError(error);
+            }
+        },
+    );
+
+    // Update Project Item Tool
+    server.tool(
+        'update_project_item',
+        'Move an item between columns in a GitHub project',
+        {
+            project_id: z.number().describe('Project ID'),
+            item_id: z.number().describe('Card ID to move'),
+            column_id: z.number().describe('Column ID to move the card to'),
+            position: z
+                .union([z.enum(['top', 'bottom']), z.number()])
+                .optional()
+                .describe('Position in the column (top, bottom, or specific position)'),
+        },
+        async (args, _extra) => {
+            try {
+                await projectService.updateProjectItem({
+                    project_id: Number(args.project_id),
+                    item_id: Number(args.item_id),
+                    column_id: Number(args.column_id),
+                    position: args.position,
+                });
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({
+                                success: true,
+                                message: `Card ${args.item_id} moved to column ${args.column_id}`,
+                            }),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return handleToolError(error);
+            }
+        },
+    );
+
+    // List Project Items Tool
+    server.tool(
+        'list_project_items',
+        'List items in a GitHub project',
+        {
+            project_id: z.number().describe('Project ID'),
+            column_id: z.number().optional().describe('Column ID to filter by'),
+        },
+        async (args, _extra) => {
+            try {
+                const cards = await projectService.listProjectItems(args);
+
+                // Format the response
+                const formattedCards = cards.map((card: any) => ({
+                    id: card.id,
+                    url: card.url,
+                    created_at: card.created_at,
+                    updated_at: card.updated_at,
+                    column: card.column,
+                    content_url: card.content_url,
+                    note: card.note,
+                }));
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({
+                                success: true,
+                                count: formattedCards.length,
+                                cards: formattedCards,
+                            }),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return handleToolError(error);
+            }
+        },
+    );
+}
+
+/**
+ * Register GitHub Pull Request Management tools
+ */
+function registerPullRequestTools(server: McpServer, pullRequestService: GitHubPullRequestService) {
+    // Create Pull Request Tool
+    server.tool(
+        'create_pull_request',
+        'Create a new pull request in a GitHub repository',
+        {
+            owner: z.string().describe('Repository owner (username or organization)'),
+            repo: z.string().describe('Repository name'),
+            title: z.string().describe('Pull request title'),
+            body: z.string().optional().describe('Pull request body/description'),
+            head: z.string().describe('The name of the branch where your changes are implemented'),
+            base: z.string().describe('The name of the branch you want the changes pulled into'),
+            draft: z.boolean().optional().describe('Whether to create the pull request as a draft'),
+            maintainer_can_modify: z.boolean().optional().describe('Whether maintainers can modify the pull request'),
+        },
+        async (args, _extra) => {
+            try {
+                const pullRequest = await pullRequestService.createPullRequest(args);
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({
+                                success: true,
+                                pull_request: {
+                                    number: pullRequest.number,
+                                    title: pullRequest.title,
+                                    html_url: pullRequest.html_url,
+                                    state: pullRequest.state,
+                                    created_at: pullRequest.created_at,
+                                },
+                            }),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return handleToolError(error);
+            }
+        },
+    );
+
+    // Update Pull Request Tool
+    server.tool(
+        'update_pull_request',
+        'Update an existing pull request in a GitHub repository',
+        {
+            owner: z.string().describe('Repository owner (username or organization)'),
+            repo: z.string().describe('Repository name'),
+            pull_number: z.number().describe('Pull request number'),
+            title: z.string().optional().describe('New pull request title'),
+            body: z.string().optional().describe('New pull request body'),
+            state: z.enum(['open', 'closed']).optional().describe('New pull request state'),
+            base: z.string().optional().describe('The name of the branch you want the changes pulled into'),
+            maintainer_can_modify: z.boolean().optional().describe('Whether maintainers can modify the pull request'),
+        },
+        async (args, _extra) => {
+            try {
+                const pullRequest = await pullRequestService.updatePullRequest(args);
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({
+                                success: true,
+                                pull_request: {
+                                    number: pullRequest.number,
+                                    title: pullRequest.title,
+                                    html_url: pullRequest.html_url,
+                                    state: pullRequest.state,
+                                    updated_at: pullRequest.updated_at,
+                                },
+                            }),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return handleToolError(error);
+            }
+        },
+    );
+
+    // List Pull Requests Tool
+    server.tool(
+        'list_pull_requests',
+        'List pull requests in a GitHub repository with filtering options',
+        {
+            owner: z.string().describe('Repository owner (username or organization)'),
+            repo: z.string().describe('Repository name'),
+            state: z.enum(['open', 'closed', 'all']).optional().describe('Pull request state'),
+            head: z.string().optional().describe('Filter by head branch'),
+            base: z.string().optional().describe('Filter by base branch'),
+            sort: z.enum(['created', 'updated', 'popularity', 'long-running']).optional().describe('Sort field'),
+            direction: z.enum(['asc', 'desc']).optional().describe('Sort direction'),
+            per_page: z.number().optional().describe('Results per page'),
+            page: z.number().optional().describe('Page number'),
+        },
+        async (args, _extra) => {
+            try {
+                const pullRequests = await pullRequestService.listPullRequests(args);
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({
+                                success: true,
+                                pull_requests: pullRequests.map((pr) => ({
+                                    number: pr.number,
+                                    title: pr.title,
+                                    html_url: pr.html_url,
+                                    state: pr.state,
+                                    created_at: pr.created_at,
+                                    updated_at: pr.updated_at,
+                                })),
+                            }),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return handleToolError(error);
+            }
+        },
+    );
+
+    // Get Pull Request Tool
+    server.tool(
+        'get_pull_request',
+        'Get details of a specific pull request in a GitHub repository',
+        {
+            owner: z.string().describe('Repository owner (username or organization)'),
+            repo: z.string().describe('Repository name'),
+            pull_number: z.number().describe('Pull request number'),
+        },
+        async (args, _extra) => {
+            try {
+                const pullRequest = await pullRequestService.getPullRequest(args);
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({
+                                success: true,
+                                pull_request: {
+                                    number: pullRequest.number,
+                                    title: pullRequest.title,
+                                    body: pullRequest.body,
+                                    html_url: pullRequest.html_url,
+                                    state: pullRequest.state,
+                                    created_at: pullRequest.created_at,
+                                    updated_at: pullRequest.updated_at,
+                                    merged_at: pullRequest.merged_at,
+                                    head: pullRequest.head,
+                                    base: pullRequest.base,
+                                    user: pullRequest.user,
+                                    assignees: pullRequest.assignees,
+                                    requested_reviewers: pullRequest.requested_reviewers,
+                                    labels: pullRequest.labels,
+                                    draft: pullRequest.draft,
+                                },
+                            }),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return handleToolError(error);
+            }
+        },
+    );
+
+    // Merge Pull Request Tool
+    server.tool(
+        'merge_pull_request',
+        'Merge a pull request',
+        {
+            owner: z.string().describe('Repository owner (username or organization)'),
+            repo: z.string().describe('Repository name'),
+            pull_number: z.number().describe('Pull request number'),
+            commit_title: z.string().optional().describe('Title for the automatic commit message'),
+            commit_message: z.string().optional().describe('Extra detail to append to automatic commit message'),
+            merge_method: z.enum(['merge', 'squash', 'rebase']).optional().describe('Merge method to use'),
+        },
+        async (args, _extra) => {
+            try {
+                const result = await pullRequestService.mergePullRequest(args);
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({
+                                success: true,
+                                merged: result.merged,
+                                message: result.message,
+                                sha: result.sha,
+                            }),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return handleToolError(error);
+            }
+        },
+    );
+
+    // Check If Pull Request Is Merged Tool
+    server.tool(
+        'is_pull_request_merged',
+        'Check if a pull request has been merged',
+        {
+            owner: z.string().describe('Repository owner (username or organization)'),
+            repo: z.string().describe('Repository name'),
+            pull_number: z.number().describe('Pull request number'),
+        },
+        async (args, _extra) => {
+            try {
+                const { owner, repo, pull_number } = args;
+                const isMerged = await pullRequestService.isPullRequestMerged(owner, repo, pull_number);
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({
+                                success: true,
+                                merged: isMerged,
+                            }),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return handleToolError(error);
+            }
+        },
+    );
+
+    // Create Pull Request Review Tool
+    server.tool(
+        'create_pull_request_review',
+        'Create a review for a pull request',
+        {
+            owner: z.string().describe('Repository owner (username or organization)'),
+            repo: z.string().describe('Repository name'),
+            pull_number: z.number().describe('Pull request number'),
+            body: z.string().optional().describe('The body text of the review'),
+            event: z
+                .enum(['APPROVE', 'REQUEST_CHANGES', 'COMMENT'])
+                .optional()
+                .describe('The review action to perform'),
+            comments: z
+                .array(
+                    z.object({
+                        path: z.string().describe('The relative path to the file being commented on'),
+                        position: z.number().describe('The position in the diff where the comment should be placed'),
+                        body: z.string().describe('The text of the comment'),
+                    }),
+                )
+                .optional()
+                .describe('Comments to post as part of the review'),
+        },
+        async (args, _extra) => {
+            try {
+                const review = await pullRequestService.createPullRequestReview(args);
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({
+                                success: true,
+                                review: {
+                                    id: review.id,
+                                    body: review.body,
+                                    state: review.state,
+                                    html_url: review.html_url,
+                                    user: review.user,
+                                    submitted_at: review.submitted_at,
+                                },
+                            }),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return handleToolError(error);
+            }
+        },
+    );
+
+    // List Pull Request Reviews Tool
+    server.tool(
+        'list_pull_request_reviews',
+        'List reviews for a pull request',
+        {
+            owner: z.string().describe('Repository owner (username or organization)'),
+            repo: z.string().describe('Repository name'),
+            pull_number: z.number().describe('Pull request number'),
+            per_page: z.number().optional().describe('Results per page'),
+            page: z.number().optional().describe('Page number'),
+        },
+        async (args, _extra) => {
+            try {
+                const reviews = await pullRequestService.listPullRequestReviews(args);
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({
+                                success: true,
+                                reviews: reviews.map((review) => ({
+                                    id: review.id,
+                                    body: review.body,
+                                    state: review.state,
+                                    html_url: review.html_url,
+                                    user: review.user,
+                                    submitted_at: review.submitted_at,
+                                })),
+                            }),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return handleToolError(error);
+            }
+        },
+    );
+
+    // Create Pull Request Review Comment Tool
+    server.tool(
+        'create_pull_request_review_comment',
+        'Create a review comment for a pull request',
+        {
+            owner: z.string().describe('Repository owner (username or organization)'),
+            repo: z.string().describe('Repository name'),
+            pull_number: z.number().describe('Pull request number'),
+            body: z.string().describe('The text of the review comment'),
+            commit_id: z.string().optional().describe('The SHA of the commit to comment on'),
+            path: z.string().optional().describe('The relative path to the file being commented on'),
+            position: z.number().optional().describe('The position in the diff where the comment should be placed'),
+            in_reply_to: z.number().optional().describe('The comment ID to reply to'),
+        },
+        async (args, _extra) => {
+            try {
+                const comment = await pullRequestService.createPullRequestReviewComment(args);
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({
+                                success: true,
+                                comment: {
+                                    id: comment.id,
+                                    body: comment.body,
+                                    html_url: comment.html_url,
+                                    user: comment.user,
+                                    created_at: comment.created_at,
+                                },
+                            }),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return handleToolError(error);
+            }
+        },
+    );
+
+    // List Pull Request Review Comments Tool
+    server.tool(
+        'list_pull_request_review_comments',
+        'List review comments for a pull request',
+        {
+            owner: z.string().describe('Repository owner (username or organization)'),
+            repo: z.string().describe('Repository name'),
+            pull_number: z.number().describe('Pull request number'),
+            sort: z.enum(['created', 'updated']).optional().describe('Sort field'),
+            direction: z.enum(['asc', 'desc']).optional().describe('Sort direction'),
+            since: z.string().optional().describe('Only comments updated at or after this time are returned'),
+            per_page: z.number().optional().describe('Results per page'),
+            page: z.number().optional().describe('Page number'),
+        },
+        async (args, _extra) => {
+            try {
+                const comments = await pullRequestService.listPullRequestReviewComments(args);
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({
+                                success: true,
+                                comments: comments.map((comment) => ({
+                                    id: comment.id,
+                                    body: comment.body,
+                                    html_url: comment.html_url,
+                                    user: comment.user,
+                                    created_at: comment.created_at,
+                                    updated_at: comment.updated_at,
+                                })),
+                            }),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return handleToolError(error);
+            }
+        },
+    );
+
+    // Request Reviewers Tool
+    server.tool(
+        'request_reviewers',
+        'Request reviewers for a pull request',
+        {
+            owner: z.string().describe('Repository owner (username or organization)'),
+            repo: z.string().describe('Repository name'),
+            pull_number: z.number().describe('Pull request number'),
+            reviewers: z.array(z.string()).optional().describe('Usernames of people to request a review from'),
+            team_reviewers: z.array(z.string()).optional().describe('Names of teams to request a review from'),
+        },
+        async (args, _extra) => {
+            try {
+                const pullRequest = await pullRequestService.requestReviewers(args);
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({
+                                success: true,
+                                pull_request: {
+                                    number: pullRequest.number,
+                                    requested_reviewers: pullRequest.requested_reviewers,
+                                    requested_teams: pullRequest.requested_teams,
+                                },
+                            }),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return handleToolError(error);
+            }
+        },
+    );
+
+    // Remove Requested Reviewers Tool
+    server.tool(
+        'remove_requested_reviewers',
+        'Remove requested reviewers from a pull request',
+        {
+            owner: z.string().describe('Repository owner (username or organization)'),
+            repo: z.string().describe('Repository name'),
+            pull_number: z.number().describe('Pull request number'),
+            reviewers: z.array(z.string()).describe('Usernames of people to remove from the review request'),
+            team_reviewers: z.array(z.string()).optional().describe('Names of teams to remove from the review request'),
+        },
+        async (args, _extra) => {
+            try {
+                const { owner, repo, pull_number, reviewers, team_reviewers } = args;
+                const pullRequest = await pullRequestService.removeRequestedReviewers(
+                    owner,
+                    repo,
+                    pull_number,
+                    reviewers,
+                    team_reviewers,
+                );
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({
+                                success: true,
+                                pull_request: {
+                                    number: pullRequest.number,
+                                    requested_reviewers: pullRequest.requested_reviewers,
+                                    requested_teams: pullRequest.requested_teams,
+                                },
+                            }),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return handleToolError(error);
+            }
+        },
+    );
+
+    // Update Pull Request Branch Tool
+    server.tool(
+        'update_pull_request_branch',
+        'Update a pull request branch with the latest upstream changes',
+        {
+            owner: z.string().describe('Repository owner (username or organization)'),
+            repo: z.string().describe('Repository name'),
+            pull_number: z.number().describe('Pull request number'),
+            expected_head_sha: z.string().optional().describe('The expected SHA of the pull request head'),
+        },
+        async (args, _extra) => {
+            try {
+                const result = await pullRequestService.updatePullRequestBranch(args);
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({
+                                success: true,
+                                message: result.message,
+                                url: result.url,
+                            }),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return handleToolError(error);
+            }
+        },
+    );
+}
+
+/**
+ * Handle errors from tool execution
+ */
+function handleToolError(error: unknown) {
+    let errorMessage = 'An unknown error occurred';
+    let errorType = 'UnknownError';
+
+    if (error instanceof AuthenticationError) {
+        errorMessage = error.message;
+        errorType = 'AuthenticationError';
+    } else if (error instanceof ResourceNotFoundError) {
+        errorMessage = error.message;
+        errorType = 'ResourceNotFoundError';
+    } else if (error instanceof ValidationError) {
+        errorMessage = error.message;
+        errorType = 'ValidationError';
+    } else if (error instanceof Error) {
+        errorMessage = error.message;
+        errorType = error.name;
+    }
+
+    return {
+        content: [
+            {
+                type: 'text' as const,
+                text: JSON.stringify({
+                    success: false,
+                    error: {
+                        type: errorType,
+                        message: errorMessage,
+                    },
+                }),
+            },
+        ],
+    };
+}


### PR DESCRIPTION
# Pull Request

## Description

This PR updates the GitHub Project Manager README to document the available transport options. It adds comprehensive information about both the default Stdio transport and the Server-Sent Events (SSE) transport, including command-line parameters and programmatic usage examples.

## Type of change

- [x] Documentation update
- [x] MCP implementation or update

## How Has This Been Tested?

- Verified the README changes are accurate and reflect the available functionality
- Built the project to ensure no build errors
- Ran validation to ensure no issues with the changes

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] The changes file has been updated with the changes

## Additional context

The PR adds documentation for two transport options:
1. Stdio Transport (Default) - For direct CLI integrations and local usage
2. Server-Sent Events (SSE) Transport - For remote setups and web integrations with HTTP

It includes command line examples and programmatic usage for both options.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new Server-Sent Events (SSE) transport option alongside the existing Stdio method, configurable via command line parameters.
- **Documentation**
	- Expanded the README with a new "Transport Options" section, providing clear usage examples and instructions for both transport methods.
- **Chores**
	- Updated the package version and dependencies to support the new transport functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->